### PR TITLE
ToThrow should be ToMatch

### DIFF
--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -120,7 +120,7 @@ test('the data is peanut butter', async () => {
 });
 
 test('the fetch fails with an error', async () => {
-  await expect(fetchData()).rejects.toThrow('error');
+  await expect(fetchData()).rejects.toMatch('error');
 });
 ```
 


### PR DESCRIPTION
## Summary
Minor typo in the example code. The example should be using ToMatch not ToThrow.

## Test plan
Preview in Github looks great

reviewed for pull in to main repo but requested that I also update the versioned files too.  Will merge to my fork main branch and then open a new PR